### PR TITLE
add #!/bin/bash to build.sh

### DIFF
--- a/AD_1DA/build.sh
+++ b/AD_1DA/build.sh
@@ -1,1 +1,2 @@
+#!/bin/bash
 gcc *.c -o main -lbfd -lkeystone -lstdc++ -lm -lcapstone -g && chmod +x regen.sh && chmod +x demo.sh && ./regen.sh && nasm -f elf64 test.asm -o test.o && ld test.o -o test && ./test


### PR DESCRIPTION
without this you will get the following error
Failed to execute process './build.sh'. Reason:
exec: Exec format error
The file './build.sh' is marked as an executable but could not be run by the operating system.